### PR TITLE
#2 Make 4.6 a permitted version for the .NET framework

### DIFF
--- a/SnowPlow/source.extension.vsixmanifest
+++ b/SnowPlow/source.extension.vsixmanifest
@@ -17,7 +17,7 @@
     <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,4.6]" />
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" Path="|SnowPlow|" d:ProjectName="SnowPlow" />


### PR DESCRIPTION
I have added 4.6 as a permitted version for the .NET framework by changing the dependency version string.