### PR TITLE
Added support for using SnowPlow with vstest.console.exe.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+ - Added support for using SnowPlow with vstest.console.exe.
 
 ## [1.1.8.0] - 2018-1-16
 ### Added

--- a/SnowPlow/Properties/AssemblyInfo.cs
+++ b/SnowPlow/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.1")]
-[assembly: AssemblyFileVersion("1.1.8.0")]
+[assembly: AssemblyFileVersion("1.1.9.0")]

--- a/SnowPlow/SnowPlow.csproj
+++ b/SnowPlow/SnowPlow.csproj
@@ -38,7 +38,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SnowPlow</RootNamespace>
-    <AssemblyName>SnowPlow</AssemblyName>
+    <AssemblyName>SnowPlow.TestAdapter</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
@@ -75,13 +75,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
-      <HintPath>..\..\..\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestWindow.Core">
-      <HintPath>..\..\..\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.Core.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestWindow.Interfaces">
-      <HintPath>..\..\..\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.Interfaces.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/SnowPlow/source.extension.vsixmanifest
+++ b/SnowPlow/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="SnowPlow.9db87109-67e6-40f0-9b39-5a0d8510a1dd" Version="1.1.8.0" Language="en-US" Publisher="Adrian Cowan" />
+        <Identity Id="SnowPlow.9db87109-67e6-40f0-9b39-5a0d8510a1dd" Version="1.1.9.0" Language="en-US" Publisher="Adrian Cowan" />
         <DisplayName>SnowPlow</DisplayName>
         <Description xml:space="preserve">Igloo/Bandit Unittest Adaptor</Description>
         <MoreInfo>https://github.com/othrayte/snowplow</MoreInfo>


### PR DESCRIPTION
This was done by renaming SnowPlow.dll to SnowPlow.TestAdapter.dll. vstest.console.exe requires the TestAdapter naming in order to discover the DLL when using the /TestAdapterPath option.